### PR TITLE
feat: 共享購物車商品數量更新、刪除共享購物車內商品

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@ import NavBar from "./components/NavBar.vue"
 import Footer from "./components/Footer.vue"
 const route = useRoute()
 
-const shouldShowFooter = computed(() => route.name !== "Cart")
+const shouldShowFooter = computed(() => !route.path.startsWith("/Cart"))
 </script>
 
 <template>

--- a/src/components/CartProduct.vue
+++ b/src/components/CartProduct.vue
@@ -59,8 +59,8 @@ const handleDelete = () => {
         </button>
       </div>
       <div class="flex gap-2 items-center">
-        <span class="font-black text-orange-500 text-sm md:text-base">NT${{ props.salePrice }}</span>
-        <span class="line-through text-gray-400 text-xs md:text-sm">NT${{ props.originalPrice }}</span>
+        <span class="font-black text-orange-500 text-sm md:text-base">NT${{ Number(props.salePrice).toLocaleString() }}</span>
+        <span class="line-through text-gray-400 text-xs md:text-sm">NT${{ Number(props.originalPrice).toLocaleString() }}</span>
       </div>
       <!-- 數量 -->
       <div class="flex justify-end md:justify-end">

--- a/src/components/CartProduct.vue
+++ b/src/components/CartProduct.vue
@@ -1,8 +1,6 @@
 <script setup>
 import { ref } from "vue"
-import axios from "axios"
-
-const userId = localStorage.getItem("UID")
+import { ElMessage } from "element-plus"
 
 const props = defineProps({
   id: {
@@ -37,6 +35,8 @@ const decrease = () => {
   if (counter.value > 1) {
     counter.value--
     emits("updateQuantity", { id: props.id, quantity: counter.value })
+  } else {
+    ElMessage.error("商品數量不得小於一")
   }
 }
 

--- a/src/components/ProductItem.vue
+++ b/src/components/ProductItem.vue
@@ -44,8 +44,8 @@ const handleAddToCart = async () => {
       </div>
       <div class="px-2.5 pt-2.5 pb-7 mb-6 text-center lg:relative lg:mb-0">
         <p class="mb-1 text-sm">{{ props.title }}</p>
-        <p class="text-base font-black">NT${{ props.price }}</p>
-        <p class="mb-1 text-base text-gray-500 line-through decoration-slate-400">NT${{ props.originalPrice }}</p>
+        <p class="text-base font-black">NT${{ props.price.toLocaleString() }}</p>
+        <p class="mb-1 text-base text-gray-500 line-through decoration-slate-400">NT${{ props.originalPrice.toLocaleString() }}</p>
         <button
           @click.prevent="handleAddToCart"
           class="cartButton absolute bottom-4 left-4 right-4 h-8 rounded bg-neutral-100 border-l-neutral-300 lg:bg-white lg:h-10 lg:left-8 lg:right-8 lg:top-[-50px] lg:hidden"

--- a/src/stores/sharedCart.js
+++ b/src/stores/sharedCart.js
@@ -125,6 +125,21 @@ export const useSharedCartStore = defineStore("sharedCart", () => {
     }
   }
 
+  // 刪除共享購物車內的商品
+  const deleteProductInSharedCart = async (groupId, productId) => {
+    try {
+      const { data } = await axios.delete(`${import.meta.env.VITE_API_URL}/sharedCart/deleteProduct/${groupId}`, {
+        data: {
+          productId,
+        },
+      })
+      return data
+    } catch (err) {
+      console.log("刪除共享購物車商品失敗", err)
+      throw err
+    }
+  }
+
   return {
     sharedCartList,
     fetchSharedCartList,
@@ -136,5 +151,6 @@ export const useSharedCartStore = defineStore("sharedCart", () => {
     addMemberToSharedCart,
     addProductToSharedCart,
     updateProductQtyToSharedCart,
+    deleteProductInSharedCart,
   }
 })

--- a/src/stores/sharedCart.js
+++ b/src/stores/sharedCart.js
@@ -111,6 +111,20 @@ export const useSharedCartStore = defineStore("sharedCart", () => {
     }
   }
 
+  // 更新購物車內的商品數量
+  const updateProductQtyToSharedCart = async (groupId, productId, totalQty) => {
+    try {
+      const { data } = axios.put(`${import.meta.env.VITE_API_URL}/sharedCart/updateProductQty/${groupId}`, {
+        productId,
+        totalQty,
+      })
+      return data
+    } catch (err) {
+      console.log("更新共享購物車商品數量失敗", err)
+      throw err
+    }
+  }
+
   return {
     sharedCartList,
     fetchSharedCartList,
@@ -121,5 +135,6 @@ export const useSharedCartStore = defineStore("sharedCart", () => {
     deleteSharedCart,
     addMemberToSharedCart,
     addProductToSharedCart,
+    updateProductQtyToSharedCart,
   }
 })

--- a/src/views/Cart.vue
+++ b/src/views/Cart.vue
@@ -375,7 +375,7 @@ watch(
               <div class="flex flex-col gap-3">
                 <div class="flex justify-between">
                   <p>小計</p>
-                  <p>NT${{ itemPrice }}</p>
+                  <p>NT${{ itemPrice.toLocaleString() }}</p>
                 </div>
                 <div class="flex justify-between">
                   <p>折扣</p>
@@ -388,7 +388,7 @@ watch(
                 <hr />
                 <div class="flex justify-between">
                   <p>合計</p>
-                  <p class="font-bold text-orange-500">NT${{ itemPrice + 60 }}</p>
+                  <p class="font-bold text-orange-500">NT${{ (itemPrice - 94 + 60).toLocaleString() }}</p>
                 </div>
               </div>
             </div>
@@ -399,7 +399,7 @@ watch(
     <!-- 前往結帳 -->
     <section class="fixed bottom-0 w-full bg-white shadow-2xl">
       <div class="flex gap-5 justify-end items-center m-5 max-w-[1365px]">
-        <p class="text-orange-500 font-bold">小計：NT${{ itemPrice }}</p>
+        <p class="text-orange-500 font-bold">合計：NT${{ (itemPrice - 94 + 60).toLocaleString() }}</p>
         <button class="bg-black px-2 py-1 text-white rounded md:px-10" @click="goToNext">前往結帳</button>
       </div>
     </section>

--- a/src/views/Cart.vue
+++ b/src/views/Cart.vue
@@ -132,7 +132,7 @@ const deleteProduct = async (id) => {
       },
     })
     .then(() => {
-      products.value = products.value.filter((product) => product.id !== id) // 從列表中移除
+      return initializeCartPage()
     })
     .catch((error) => {
       console.error("刪除商品失敗:", error)
@@ -141,7 +141,7 @@ const deleteProduct = async (id) => {
   await initializeCartPage()
 }
 
-// 更新商品
+// 更新購物車商品數量的函式
 const updateQuantity = async ({ id, quantity }) => {
   if (quantity < 1) {
     alert("數量不能小於 1")
@@ -159,7 +159,6 @@ const updateQuantity = async ({ id, quantity }) => {
         headers: { userId },
       }
     )
-
     if (response.data.success) {
       console.log("數量更新成功")
       await initializeCartPage() // 重新獲取購物車列表
@@ -169,6 +168,31 @@ const updateQuantity = async ({ id, quantity }) => {
   } catch (error) {
     console.error("更新數量時出錯", error)
     alert("更新數量時出錯，請稍後再試")
+  }
+}
+
+// 更新商品數量
+const updateProductQty = async (payload) => {
+  if (isSharedCart.value) {
+    try {
+      await SharedCartStore.updateProductQtyToSharedCart(route.params.groupId, payload.id, payload.quantity)
+    } catch (err) {
+      ElMessage.error({
+        message: "更新共享購物車商品數量失敗：" + (err.response?.data?.message || err.message),
+        type: "error",
+      })
+      console.error("更新共享購物車數量失敗：", err)
+    }
+  } else {
+    try {
+      await updateQuantity(payload)
+    } catch (err) {
+      ElMessage.error({
+        message: "更新購物車商品數量失敗：" + (err.response?.data?.message || err.message),
+        type: "error",
+      })
+      console.error("更新購物車數量失敗：", err)
+    }
   }
 }
 
@@ -272,7 +296,7 @@ watch(
               :salePrice="item.sale_price"
               :imgPath="item.image_path"
               :quantity="item.quantity"
-              @updateQuantity="updateQuantity"
+              @updateQuantity="updateProductQty"
               @deleteProduct="deleteProduct"
             />
           </section>

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -298,8 +298,8 @@ const refreshSharedCartList = async () => {
         <div class="m-4 mt-5">
           <h1 class="text-[28px]">{{ title }}</h1>
           <div class="flex">
-            <h2 class="my-5 text-[20px] font-extrabold">NT${{ salePrice }}</h2>
-            <h2 class="ml-5 mt-6 text-s font-bold text-gray-400 line-through">NT${{ originalPrice }}</h2>
+            <h2 class="my-5 text-[20px] font-extrabold">NT${{ Number(salePrice).toLocaleString() }}</h2>
+            <h2 class="ml-5 mt-6 text-s font-bold text-gray-400 line-through">NT${{ Number(originalPrice).toLocaleString() }}</h2>
           </div>
           <div class="font-extralight text-[16px]">
             <p>全館任選兩件88折，優惠後特價 NT${{ Math.ceil(salePrice * 0.88) }}</p>


### PR DESCRIPTION
- 購物車頁面如果是共享購物車，也可以更新商品數量
- 修正一般購物車刪除商品後不會重新渲染的問題
- 價格都加上千分位符號
- 共享購物車的購物車頁面也不要有 footer，所以把 App.vue 內的要不要看到 footer 的判斷方式從 route.name 改成 route.path.startsWith
- 刪除共享購物車內商品