### PR TITLE
fix : #126 補充註解及修改樣式

### DIFF
--- a/src/views/MemberOrder.vue
+++ b/src/views/MemberOrder.vue
@@ -186,9 +186,10 @@ onMounted(async () => {
 		display: none;
 	}
 	.orderTable tbody td {
-		margin: 0 40px;
+		margin: auto;
 		display: block;
 		border: 1px solid #ddd;
+		width: 80%;
 	}
 	.last {
 		margin-bottom: 20px !important ;

--- a/src/views/MemberWishList.vue
+++ b/src/views/MemberWishList.vue
@@ -159,6 +159,9 @@ const refreshSharedCartList = async () => {
         :key="item.id"
         class="commodityList grid grid-cols-12 items-center border-b py-[15px] mx-[-10px] bg-white hover:bg-[#F5F5F5]"
       >
+        <div class="deleteIcon" @click="removeItem(item.id)">
+          <font-awesome-icon :icon="['fas', 'times']" />
+        </div>
         <div class="commodityImg col-span-2 px-[15px]">
           <router-link :to="{ name: 'products-detail(連後端)', params: { productId: item.products.product_id } }">
             <img
@@ -212,7 +215,7 @@ const refreshSharedCartList = async () => {
   border-bottom: 1px solid rgba(221, 221, 221, 0.5);
 }
 .btn {
-  width: 160px;
+  width: 90%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -225,6 +228,8 @@ const refreshSharedCartList = async () => {
   font-weight: bold;
   cursor: pointer;
   transition: background-color 0.3s ease;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 .btn:hover {
   background-color: #7994a0;
@@ -246,16 +251,26 @@ const refreshSharedCartList = async () => {
 .salePrice {
   font-size: 12px;
 }
-
+.deleteIcon{
+  display: none;
+}
 @media (max-width: 1024px) and (min-width: 769px) {
-  .btn {
-    display: none;
-  }
   .fa-cart-shopping {
     display: block !important;
   }
 }
 @media (max-width: 768px) {
+  .btn{
+    margin: 5px auto;
+  }
+  .deleteIcon{
+    display: block;
+    position: absolute;
+    top: 10px; 
+    right: 10px;
+    cursor: pointer; 
+  }
+  
   .wishlistMain {
     width: 100%;
   }
@@ -270,6 +285,7 @@ const refreshSharedCartList = async () => {
     padding: 0;
     border: 1px solid #ddd;
     padding-top: 15px;
+    position: relative;
   }
   .commodityList:nth-of-type(n + 2) {
     margin-top: 20px;

--- a/src/views/MemberWishList.vue
+++ b/src/views/MemberWishList.vue
@@ -34,6 +34,7 @@ onMounted(async () => {
     console.error("無法獲取願望清單資料：", error)
   }
 })
+// 刪除願望清單的方法
 const removeItem = async (id) => {
   try {
     await axios.delete(`${API_URL}/wishlist/delete/${id}`)

--- a/src/views/OrderDetails.vue
+++ b/src/views/OrderDetails.vue
@@ -74,10 +74,12 @@ onMounted(async () => {
 						</div>
 						<div v-for="product in productInfo" :key="product.product_id" class="itemsCard">
 							<div class="itemsName">
-								<img :src="getImageUrl(product.image_path.image_path)" alt="商品圖片" />
-								{{ product.product_name }}
-								<p>Silver / 銀色</p>
-								<p>內圍直徑 1.7cm (#12)</p>
+								<router-link :to="{ name: 'products-detail(連後端)', params: { productId: product.product_id } }">
+									<img :src="getImageUrl(product.image_path.image_path)" alt="商品圖片" />
+									{{ product.product_name }}
+									<p>Silver / 銀色</p>
+									<p>內圍直徑 1.7cm (#12)</p>
+								</router-link>
 							</div>
 							<div class="itemsCoupon"></div>
 							<div class="itemsPrice">NT${{ product.sale_price }}</div>
@@ -121,7 +123,7 @@ onMounted(async () => {
 					<ul>
 						<li>名字: {{ customerInfo.cuName }}</li>
 						<li>電話: {{ customerInfo.cuPhone }}</li>
-						<li>性別: {{ customerInfo.gender || "未提供" }}</li>
+						<li>性別: 	{{ customerInfo.gender === "o" ? "秘密" : customerInfo.gender === "f" ? "女" : customerInfo.gender === "m" ? "男" : "未知" }}</li>
 					</ul>
 				</div>
 				<div class="deliveryImformation">
@@ -322,6 +324,7 @@ hr {
 }
 
 .addCartAgain {
+	display: flex;
 	padding: 10px;
 	border: 1px solid #ddd;
 	border-top: none;
@@ -330,18 +333,10 @@ hr {
 	margin-bottom: 30px;
 	text-align: center;
 	justify-content: center;
-
 	align-items: center;
 }
 
-.addCartUp {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-	font-size: 14px;
-	align-self: center;
-}
+
 
 .addCartAgain .btn {
 	position: absolute;
@@ -469,6 +464,10 @@ hr {
 		display: flex;
 		flex-wrap: wrap;
 		width: 100%;
+	}
+	.itemsCard img {
+		width: 100%;
+		height: auto;
 	}
 	.itemsCoupon {
 		display: none;

--- a/src/views/OrderDetails.vue
+++ b/src/views/OrderDetails.vue
@@ -85,23 +85,23 @@ onMounted(async () => {
 							<div class="itemsPrice">NT${{ product.sale_price }}</div>
 							<div class="itemsQuantity"><span>數量:</span>{{ product.quantity }}</div>
 							<div class="itemsTotal">
-								{{ product.sale_price * product.quantity }}
+								NT${{ product.sale_price * product.quantity }}
 							</div>
 						</div>
-						<div class="couponUsed">
+						<!-- <div class="couponUsed">
 							<h5>已使用之優惠</h5>
 							<span class="coupon-type">優惠促銷</span>
 							<p>限時全館$350免運</p>
-						</div>
+						</div> -->
 					</div>
 					<div class="ordersTotal">
 						<div class="ordersTotalCard">
 							<div class="subtotal">
-								小計:<span>{{ totalPrice }}</span>
+								小計:<span>NT${{ totalPrice }}</span>
 							</div>
 							<div class="delivery">運費:<span>免運</span></div>
 							<div class="total">
-								合計:<span>{{ totalPrice }}</span>
+								合計:<span>NT${{ totalPrice }}</span>
 							</div>
 						</div>
 					</div>
@@ -219,6 +219,7 @@ h4 {
 	padding: 15px 0;
 	border: 1px solid #ddd;
 	border-top: none;
+	justify-content: space-between
 }
 
 .ordersTitleName,

--- a/src/views/OrderDetails.vue
+++ b/src/views/OrderDetails.vue
@@ -25,13 +25,13 @@ const getImageUrl = (imagePath) => {
 	const cleanedPath = imagePath.startsWith("./") ? imagePath.slice(1) : imagePath
 	return `${API_URL}/${cleanedPath}`
 }
-//總價
+// 總價
 const totalPrice = computed(() => {
 	return productInfo.value.reduce((sum, product) => {
 		return sum + product.sale_price * product.quantity
 	}, 0)
 })
-//商品數
+// 商品數
 const productCount = computed(() => {
 	return productInfo.value.length
 })

--- a/src/views/OrderDetails.vue
+++ b/src/views/OrderDetails.vue
@@ -43,8 +43,8 @@ onMounted(async () => {
 
 		// 直接將返回的資料綁定給 productInfo
 		productInfo.value = data.productInfo || []
-		orderInfo.value = data.orderInfo || {}
-		customerInfo.value = data.customerInfo || {}
+		orderInfo.value = data.orderInfo?.[0] || {}
+		customerInfo.value = data.customerInfo?.[0] || {}
 		deliveryInfo.value = data.deliveryInfo || {}
 		paymentInfo.value = data.paymentInfo || {}
 	} catch (error) {
@@ -113,9 +113,7 @@ onMounted(async () => {
 					<h4>訂單資訊</h4>
 					<ul>
 						<li>訂單號碼:{{ purchaseID }}</li>
-						<li>訂單電郵:</li>
-						<li>訂單日期:</li>
-						<li>訂單狀態:</li>
+						<li>訂單狀態: 已完成</li>
 					</ul>
 				</div>
 				<div class="customImformation">
@@ -124,19 +122,15 @@ onMounted(async () => {
 						<li>名字: {{ customerInfo.cuName }}</li>
 						<li>電話: {{ customerInfo.cuPhone }}</li>
 						<li>性別: {{ customerInfo.gender || "未提供" }}</li>
-						<li>生日: 1990/01/01</li>
 					</ul>
 				</div>
 				<div class="deliveryImformation">
 					<h4>送貨資訊</h4>
 					<ul>
-						<li>送貨方式</li>
-						<li>送貨狀態</li>
-						<li>7-11</li>
-						<li>7-11</li>
+						<li>送貨方式: {{ orderInfo.DeliveryWay }}</li>
+						<li>送貨狀態: 已完成</li>
 						<li>收件人名字: {{ deliveryInfo.acName }}</li>
 						<li>收件人電話: {{ deliveryInfo.acPhone }}</li>
-						<li>配送編號</li>
 						<li>配送地址: {{ deliveryInfo.addr }}</li>
 					</ul>
 				</div>
@@ -144,14 +138,9 @@ onMounted(async () => {
 				<div class="paymentImformation">
 					<h4>付款資訊</h4>
 					<ul>
-						<li>付款方式</li>
+						<li>付款方式: {{ orderInfo.payWay }}</li>
 						<li>卡片名稱: {{ paymentInfo?.cardName || "N/A" }}</li>
 						<li>有效日期: {{ paymentInfo?.efficentDate || "N/A" }}</li>
-						<li>付款狀態</li>
-						<li>付款指示</li>
-						<li>發票狀態</li>
-						<li>發票申請類型</li>
-						<li>發票載具類型</li>
 					</ul>
 				</div>
 			</div>

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -281,27 +281,28 @@ const toggleReview = () => {
   isDescription.value = false
   isReview.value = true
 }
-//追蹤清單
+// 追蹤清單
 const wishlist = ref([])
-//檢查這個商品是不是已經在願望清單裡ㄌ
+// 檢查這個商品是不是已經在願望清單裡ㄌ
 const fetchWishlist = async () => {
   try {
     const response = await axios.get(`${API_URL}/wishlist/${userId}`)
-    wishlist.value = response.data.data // API 回傳的 `data` 陣列
+    wishlist.value = response.data.data // 回傳這個會員有哪些商品在願望清單裡
   } catch (error) {
     wishlist.value = []
   }
 }
+// 檢查願望清單的商品是不是當前瀏覽的商品
 const isInWishlist = computed(() => {
-  return wishlist.value.some((item) => item.wishlists_products_id === Number(productId.value))
+  return wishlist.value.some((item) => item.wishlists_products_id === Number(productId.value)) // 這會返回一個布林值
 })
-//加入刪除願望清單ㄉ方法
+// 加入刪除願望清單ㄉ方法
 const toggleWishlist = async () => {
   if (!userId) {
     ElMessage.warning("請先登入以使用願望清單功能")
     return
   }
-  
+// 如果現在看的商品有在願望清單裡的話就刪除
   if (isInWishlist.value) {
     try {
       const wishlistItem = wishlist.value.find((item) => item.wishlists_products_id === Number(productId.value))
@@ -314,6 +315,7 @@ const toggleWishlist = async () => {
       ElMessage.error("移除失敗")
     }
   } else {
+// 如果不在願望清單就post進去資料庫
     try {
       const response = await axios.post(`${API_URL}/wishlist`, {
         wishlists_members_id: userId,
@@ -327,7 +329,7 @@ const toggleWishlist = async () => {
     }
   }
 }
-//評論頁
+// 評論頁
 const props = defineProps({
   productId: {
     type: Number,

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -294,7 +294,6 @@ const fetchWishlist = async () => {
     const response = await axios.get(`${API_URL}/wishlist/${userId}`)
     wishlist.value = response.data.data // API 回傳的 `data` 陣列
   } catch (error) {
-    console.error("無法取得願望清單：", error.response || error.message)
     wishlist.value = []
   }
 }
@@ -303,6 +302,11 @@ const isInWishlist = computed(() => {
 })
 //加入刪除願望清單ㄉ方法
 const toggleWishlist = async () => {
+  if (!userId) {
+    ElMessage.warning("請先登入以使用願望清單功能")
+    return
+  }
+  
   if (isInWishlist.value) {
     try {
       const wishlistItem = wishlist.value.find((item) => item.wishlists_products_id === Number(productId.value))

--- a/src/views/ProductDetail.vue
+++ b/src/views/ProductDetail.vue
@@ -61,7 +61,8 @@ onMounted(async () => {
     // 取得使用者名稱
     await fetchuserName()
   }
-
+  // 取得願望清單狀態
+  fetchWishlist()
   initializeSwiper()
 })
 
@@ -279,6 +280,7 @@ const toggleDescription = () => {
 const toggleReview = () => {
   isDescription.value = false
   isReview.value = true
+}
 //追蹤清單
 const wishlist = ref([])
 //檢查這個商品是不是已經在願望清單裡ㄌ
@@ -459,7 +461,9 @@ const props = defineProps({
             </button>
           </div>
           <div class="mx-auto my-5 flex justify-center text-sm hover:cursor-pointer">
-            <p :class="{ active: isSubscribe }" @click="toggleHeart" :style="heartColor"><i class="fa-regular fa-heart mr-1"></i>加入追蹤清單</p>
+            <p :class="{ active: isSubscribe }" @click="toggleWishlist">
+              <i :class="isInWishlist ? 'fa-solid fa-heart' : 'fa-regular fa-heart'"></i>加入追蹤清單
+            </p>         
           </div>
           <div class="promotionalContainer relative mx-5 mt-5">
             <p class="mx-[7px] text-sm pl-[10px]">

--- a/src/views/product_review_comments.vue
+++ b/src/views/product_review_comments.vue
@@ -24,8 +24,9 @@ onMounted(async () => {
 
 		if (response.data.status === "Success") {
 			// 會員資料不會變動，所以只需要取一次
-			user_id.value = response.data.user_id
-			username.value = response.data.username
+			const { user_id, username } = response.data
+			user_id.value = user_id
+			username.value = username
 			// 下面這些是要給前端渲染的
 			products.value = response.data.data.map((product) => ({
 				...product,

--- a/src/views/product_review_comments.vue
+++ b/src/views/product_review_comments.vue
@@ -23,12 +23,14 @@ onMounted(async () => {
 		const response = await axios.get(`${API_URL}/comment/info/${purchaseID}`)
 
 		if (response.data.status === "Success") {
+			// 會員資料不會變動，所以只需要取一次
 			user_id.value = response.data.user_id
 			username.value = response.data.username
+			// 下面這些是要給前端渲染的
 			products.value = response.data.data.map((product) => ({
 				...product,
 				commentText: "",
-				sku: 5,
+				sku: 5, // 預設評分5顆星
 			}))
 		} else {
 			console.error("無法獲取商品資訊:", response.data.message)
@@ -40,7 +42,7 @@ onMounted(async () => {
 
 // 提交評論
 const submitComment = async () => {
-	const checkComments = products.value.filter((product) => !product.commentText)
+	const checkComments = products.value.filter((product) => !product.commentText) // 判斷有沒有商品未被評價
 	if (checkComments.length > 0) {
 		ElMessage.warning("所有商品評論完才能送出喔")
 		return
@@ -63,11 +65,7 @@ const submitComment = async () => {
 		// 確認所有請求是否成功
 		const allSuccess = responses.every((response) => response.data.status === "Success")
 		if (allSuccess) {
-			console.log(products.value)
-
 			ElMessage.success("評論已成功發佈！")
-			// 清空所有商品的評論輸入框
-			products.value.forEach((product) => (product.commentText = ""))
 			router.push("/MemberOrder") // 跳轉到會員訂單頁
 		}
 	} catch (err) {

--- a/src/views/product_review_comments.vue
+++ b/src/views/product_review_comments.vue
@@ -76,7 +76,7 @@ const submitComment = async () => {
 </script>
 <template>
 	<div class="reviewMain mx-auto">
-		<div class="givingComment w-full pb-[15px]">
+		<div class="givingComment w-full pb-[15px] mt-[30px]">
 			<div class="awaitingCommentTitle border py-[10px] pl-[15px] font-semibold text-[18px]">
 				<h4>給予評價</h4>
 			</div>
@@ -85,7 +85,9 @@ const submitComment = async () => {
 				<hr class="my-[20px]" />
 				<div class="mb-[20px] commodityImformation" v-for="product in products" :key="product.product_id">
 					<div class="w-1/5 commodityImg px-[15px]">
+						<router-link :to="{ name: 'products-detail(連後端)', params: { productId: product.product_id } }">
 						<img :src="getImageUrl(product.image_paths[0])" alt="商品圖片" />
+						</router-link>
 					</div>
 					<div class="w-4/5 commodityContent">
 						<div>

--- a/src/views/product_review_comments.vue
+++ b/src/views/product_review_comments.vue
@@ -89,7 +89,7 @@ const submitComment = async () => {
 					<div class="w-1/5 commodityImg px-[15px]">
 						<img :src="getImageUrl(product.image_paths[0])" alt="商品圖片" />
 					</div>
-					<div class="w-4/5">
+					<div class="w-4/5 commodityContent">
 						<div>
 							<h5 class="font-semibold text-[14px]">
 								{{ product.product_name }}
@@ -143,7 +143,8 @@ const submitComment = async () => {
 	float: left;
 }
 .commodityImg img {
-	max-width: 195px;
+	max-width:auto;
+	min-height:195px;
 	aspect-ratio: 1 / 1;
 	object-fit: cover;
 }
@@ -178,6 +179,26 @@ textarea {
 		flex-direction: column-reverse;
 		padding: 10px 15px;
 	}
+	.commodityImformation{
+		display: flex;
+		flex-direction: column;
+	}
+	.commodityImg{
+		width: 100%;
+		padding: 0;
+	}
+	.commodityImg img{
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		padding: 0;
+		margin: 0;
+	}
+	.commodityContent{
+		width: 100%;
+		padding: 15px;
+		padding-top: 0;
+	}
 	.awaitingComment {
 		width: 100%;
 		padding: 15px;
@@ -188,6 +209,7 @@ textarea {
 		padding: 15px;
 		padding-top: 0;
 	}
+
 }
 @media (max-width: 320px) {
 	.commodityImformation {


### PR DESCRIPTION
會員訂單頁改成抓新的API去判斷該商品是否評論過，然後可以按照訂單成立順序排序，最新的會在最上面

願望清單新增手機板刪除願望清單的按鈕

訂單詳情頁新增性別、送貨資料、付款方式，然後把資料庫沒有的選項都刪掉了

商品詳情頁新增一個要登入後才能使用願望清單的判斷

商品評論頁補上註解及更新RWD

另外所有商品按下圖片都可以連結到該商品頁



